### PR TITLE
Add live card editor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,11 @@
 import heroImg from './assets/hero.svg'
 import './App.css'
+import CardEditor from './components/CardEditor.jsx'
 
 function App() {
+  if (window.location.pathname === '/editor') {
+    return <CardEditor />
+  }
 
   return (
     <div className="text-center mt-10">

--- a/src/components/CardEditor.jsx
+++ b/src/components/CardEditor.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+
+function CardEditor() {
+  const [message, setMessage] = useState('')
+  const [template, setTemplate] = useState('birthday')
+
+  const templateStyles = {
+    birthday: 'bg-pink-200',
+    congrats: 'bg-green-200',
+    holiday: 'bg-red-200',
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-4 text-blue-600">Card Editor</h1>
+      <div className="mb-4">
+        <label className="block mb-1 font-semibold" htmlFor="message">Message</label>
+        <textarea
+          id="message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          className="w-full border rounded p-2"
+          rows="4"
+        />
+      </div>
+      <div className="mb-4">
+        <label className="block mb-1 font-semibold" htmlFor="template">Template</label>
+        <select
+          id="template"
+          value={template}
+          onChange={(e) => setTemplate(e.target.value)}
+          className="w-full border rounded p-2"
+        >
+          <option value="birthday">Birthday</option>
+          <option value="congrats">Congrats</option>
+          <option value="holiday">Holiday</option>
+        </select>
+      </div>
+      <h2 className="text-xl font-bold mb-2">Preview</h2>
+      <div className={`border rounded p-6 min-h-[150px] flex items-center justify-center text-xl font-bold ${templateStyles[template]}`}>{message || 'Your message here'}</div>
+    </div>
+  )
+}
+
+export default CardEditor


### PR DESCRIPTION
## Summary
- show CardEditor when navigating to `/editor`
- implement CardEditor component with state for message and template
- render live preview as the user edits

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6698439083338f74f3d5b686edf9