### PR TITLE
Add template images and dynamic preview

### DIFF
--- a/src/assets/templates/birthday.svg
+++ b/src/assets/templates/birthday.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250">
+  <rect width="400" height="250" fill="#F9A8D4" />
+  <text x="200" y="125" font-size="30" text-anchor="middle" fill="#000" dy="10">Birthday</text>
+</svg>

--- a/src/assets/templates/congrats.svg
+++ b/src/assets/templates/congrats.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250">
+  <rect width="400" height="250" fill="#bbf7d0" />
+  <text x="200" y="125" font-size="30" text-anchor="middle" fill="#000" dy="10">Congrats</text>
+</svg>

--- a/src/assets/templates/holiday.svg
+++ b/src/assets/templates/holiday.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="250">
+  <rect width="400" height="250" fill="#fecaca" />
+  <text x="200" y="125" font-size="30" text-anchor="middle" fill="#000" dy="10">Holiday</text>
+</svg>

--- a/src/components/CardEditor.jsx
+++ b/src/components/CardEditor.jsx
@@ -1,14 +1,17 @@
 import { useState } from 'react'
+import birthdayImg from '../assets/templates/birthday.svg'
+import congratsImg from '../assets/templates/congrats.svg'
+import holidayImg from '../assets/templates/holiday.svg'
 
 function CardEditor() {
-  const [message, setMessage] = useState('')
-  const [template, setTemplate] = useState('birthday')
+  const templates = [
+    { id: 'birthday', label: 'Birthday', src: birthdayImg },
+    { id: 'congrats', label: 'Congrats', src: congratsImg },
+    { id: 'holiday', label: 'Holiday', src: holidayImg },
+  ]
 
-  const templateStyles = {
-    birthday: 'bg-pink-200',
-    congrats: 'bg-green-200',
-    holiday: 'bg-red-200',
-  }
+  const [message, setMessage] = useState('')
+  const [template, setTemplate] = useState(templates[0].id)
 
   return (
     <div className="max-w-2xl mx-auto p-4">
@@ -31,13 +34,24 @@ function CardEditor() {
           onChange={(e) => setTemplate(e.target.value)}
           className="w-full border rounded p-2"
         >
-          <option value="birthday">Birthday</option>
-          <option value="congrats">Congrats</option>
-          <option value="holiday">Holiday</option>
+          {templates.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.label}
+            </option>
+          ))}
         </select>
       </div>
       <h2 className="text-xl font-bold mb-2">Preview</h2>
-      <div className={`border rounded p-6 min-h-[150px] flex items-center justify-center text-xl font-bold ${templateStyles[template]}`}>{message || 'Your message here'}</div>
+      <div className="border rounded overflow-hidden relative">
+        <img
+          src={templates.find((t) => t.id === template).src}
+          alt={template}
+          className="w-full h-auto"
+        />
+        <div className="absolute inset-0 flex items-center justify-center text-xl font-bold">
+          {message || 'Your message here'}
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add card template SVGs under `src/assets/templates`
- update `CardEditor` to render templates dynamically and show preview image

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fab59026c8333b35ec2d594e8ae3c