### PR TITLE
Add PNG export and sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Downloading cards
+
+In the editor view you can export your card preview as a PNG image. Click **Download PNG** below the preview to save the card. You can also copy a shareable URL with **Share Link** which preserves the message and template in the query string.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "html-to-image": "^1.11.11"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2853,6 +2854,10 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "html-to-image": "^1.11.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import './App.css'
 import CardEditor from './components/CardEditor.jsx'
 
 function App() {
-  if (window.location.pathname === '/editor') {
+  if (window.location.pathname.startsWith('/editor')) {
     return <CardEditor />
   }
 

--- a/src/components/CardEditor.jsx
+++ b/src/components/CardEditor.jsx
@@ -1,13 +1,46 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { toPng } from 'html-to-image'
 
 function CardEditor() {
   const [message, setMessage] = useState('')
   const [template, setTemplate] = useState('birthday')
+  const cardRef = useRef(null)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const m = params.get('message')
+    const t = params.get('template')
+    if (m) setMessage(m)
+    if (t) setTemplate(t)
+  }, [])
 
   const templateStyles = {
     birthday: 'bg-pink-200',
     congrats: 'bg-green-200',
     holiday: 'bg-red-200',
+  }
+
+  const handleDownload = async () => {
+    if (!cardRef.current) return
+    try {
+      const dataUrl = await toPng(cardRef.current)
+      const link = document.createElement('a')
+      link.download = 'card.png'
+      link.href = dataUrl
+      link.click()
+    } catch (err) {
+      console.error('Failed to export image', err)
+    }
+  }
+
+  const handleShare = async () => {
+    const url = `${window.location.origin}/editor?message=${encodeURIComponent(message)}&template=${template}`
+    try {
+      await navigator.clipboard.writeText(url)
+      alert('Link copied to clipboard!')
+    } catch {
+      alert(`Share this link: ${url}`)
+    }
   }
 
   return (
@@ -37,7 +70,28 @@ function CardEditor() {
         </select>
       </div>
       <h2 className="text-xl font-bold mb-2">Preview</h2>
-      <div className={`border rounded p-6 min-h-[150px] flex items-center justify-center text-xl font-bold ${templateStyles[template]}`}>{message || 'Your message here'}</div>
+      <div
+        ref={cardRef}
+        className={`border rounded p-6 min-h-[150px] flex items-center justify-center text-xl font-bold ${templateStyles[template]}`}
+      >
+        {message || 'Your message here'}
+      </div>
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          onClick={handleDownload}
+        >
+          Download PNG
+        </button>
+        <button
+          type="button"
+          className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+          onClick={handleShare}
+        >
+          Share Link
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- allow use of `/editor?` query string
- add download button and share link in `CardEditor`
- document new feature
- add `html-to-image` to dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install html-to-image@1.11.11 --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fad44a8d483339d4b486a06ab2187