### PR TITLE
Fix missing module error in CardEditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
-        "html-to-image": "^1.11.11",
-      },
+        "react-dom": "^19.1.0"      },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@tailwindcss/postcss": "^4.1.8",
@@ -3535,11 +3533,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/html-to-image": {
-      "version": "1.11.11",
-      "license": "MIT"
-    },
-    "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "html-to-image": "^1.11.11"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/CardEditor.jsx
+++ b/src/components/CardEditor.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { toPng } from 'html-to-image'
+import { toPng } from '../utils/toPng'
 import birthdayImg from '../assets/templates/birthday.svg'
 import congratsImg from '../assets/templates/congrats.svg'
 import holidayImg from '../assets/templates/holiday.svg'

--- a/src/utils/toPng.js
+++ b/src/utils/toPng.js
@@ -1,0 +1,23 @@
+export async function toPng(node) {
+  if (!node) throw new Error('Node is required');
+  const width = node.offsetWidth;
+  const height = node.offsetHeight;
+  const clone = node.cloneNode(true);
+  const svg = `\n    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">\n      <foreignObject width="100%" height="100%">\n        ${new XMLSerializer().serializeToString(clone)}\n      </foreignObject>\n    </svg>`;
+  const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      resolve(canvas.toDataURL('image/png'));
+    };
+    img.onerror = reject;
+    img.src = url;
+  });
+}


### PR DESCRIPTION
## Summary
- drop `html-to-image` package and reference a local util instead
- provide `src/utils/toPng.js` for PNG exporting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f622c52ec833382f66854b855515d