### PR TITLE
Improve README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Setup
+
+Use `npm` to install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The site will be available at http://localhost:5173 by default.
+
+## Directory structure
+
+```
+celebration-cards/
+├─ index.html          # entry HTML
+├─ public/             # static assets served as-is
+├─ src/                # application source
+│  ├─ assets/          # images and card templates
+│  ├─ components/      # React components
+│  ├─ App.jsx
+│  └─ main.jsx
+└─ tailwind.config.js  # Tailwind setup
+```
+
+## Creating new templates
+
+Card templates are stored as SVG files in `src/assets/templates`. To add a new
+design, place an SVG file in this folder and import it in
+`src/components/CardEditor.jsx` by extending the `templates` array.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh


### PR DESCRIPTION
## Summary
- add setup section for running the project
- outline project directory
- explain how to create new card templates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_683fb909fffc83339215bd809820cca3