### PR TITLE
Add multi-placeholder editor and viewer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,15 @@
 import heroImg from './assets/hero.svg'
 import './App.css'
 import CardEditor from './components/CardEditor.jsx'
+import CardViewer from './components/CardViewer.jsx'
 
 function App() {
-  if (window.location.pathname.startsWith('/editor')) {
+  const path = window.location.pathname
+  if (path.startsWith('/editor')) {
     return <CardEditor />
+  }
+  if (path.startsWith('/card/')) {
+    return <CardViewer />
   }
 
   return (

--- a/src/components/CardEditor.jsx
+++ b/src/components/CardEditor.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useRef } from 'react'
 import { toPng } from '../utils/toPng'
 import birthdayImg from '../assets/templates/birthday.svg'
 import congratsImg from '../assets/templates/congrats.svg'
@@ -11,17 +11,62 @@ function CardEditor() {
     { id: 'holiday', label: 'Holiday', src: holidayImg },
   ]
 
-  const [message, setMessage] = useState('')
   const [template, setTemplate] = useState(templates[0].id)
+  const [placeholders, setPlaceholders] = useState([
+    {
+      id: 1,
+      x: 100,
+      y: 100,
+      text: 'Name',
+      font: 'Arial',
+      size: 24,
+      color: '#000000',
+    },
+  ])
+  const [dragging, setDragging] = useState(null)
   const cardRef = useRef(null)
 
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const m = params.get('message')
-    const t = params.get('template')
-    if (m) setMessage(m)
-    if (t && templates.some((tmp) => tmp.id === t)) setTemplate(t)
-  }, [])
+  const handleAdd = () => {
+    setPlaceholders((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        x: 100,
+        y: 100,
+        text: 'Text',
+        font: 'Arial',
+        size: 24,
+        color: '#000000',
+      },
+    ])
+  }
+
+  const handlePointerDown = (e, idx) => {
+    const rect = e.target.getBoundingClientRect()
+    setDragging({
+      idx,
+      offsetX: e.clientX - rect.left,
+      offsetY: e.clientY - rect.top,
+    })
+    e.target.setPointerCapture(e.pointerId)
+  }
+
+  const handlePointerMove = (e) => {
+    if (!dragging || !cardRef.current) return
+    const rect = cardRef.current.getBoundingClientRect()
+    const x = e.clientX - rect.left - dragging.offsetX
+    const y = e.clientY - rect.top - dragging.offsetY
+    setPlaceholders((prev) =>
+      prev.map((p, i) => (i === dragging.idx ? { ...p, x, y } : p))
+    )
+  }
+
+  const handlePointerUp = (e) => {
+    if (dragging) {
+      e.target.releasePointerCapture(e.pointerId)
+      setDragging(null)
+    }
+  }
 
   const handleDownload = async () => {
     if (!cardRef.current) return
@@ -37,7 +82,10 @@ function CardEditor() {
   }
 
   const handleShare = async () => {
-    const url = `${window.location.origin}/editor?message=${encodeURIComponent(message)}&template=${encodeURIComponent(template)}`
+    const id = Date.now().toString(36)
+    const data = { template, placeholders }
+    localStorage.setItem(`card-${id}`, JSON.stringify(data))
+    const url = `${window.location.origin}/card/${id}`
     try {
       await navigator.clipboard.writeText(url)
       alert('Link copied to clipboard!')
@@ -46,19 +94,15 @@ function CardEditor() {
     }
   }
 
+  const updatePlaceholder = (idx, field, value) => {
+    setPlaceholders((prev) =>
+      prev.map((p, i) => (i === idx ? { ...p, [field]: value } : p))
+    )
+  }
+
   return (
     <div className="max-w-2xl mx-auto p-4">
       <h1 className="text-3xl font-bold mb-4 text-blue-600">Card Editor</h1>
-      <div className="mb-4">
-        <label className="block mb-1 font-semibold" htmlFor="message">Message</label>
-        <textarea
-          id="message"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          className="w-full border rounded p-2"
-          rows="4"
-        />
-      </div>
       <div className="mb-4">
         <label className="block mb-1 font-semibold" htmlFor="template">Template</label>
         <select
@@ -74,17 +118,64 @@ function CardEditor() {
           ))}
         </select>
       </div>
+      {placeholders.map((p, idx) => (
+        <div key={p.id} className="mb-4 border p-2 rounded">
+          <label className="block mb-1 font-semibold">Placeholder {idx + 1} Text</label>
+          <input
+            className="w-full border rounded p-2 mb-2"
+            value={p.text}
+            onChange={(e) => updatePlaceholder(idx, 'text', e.target.value)}
+          />
+          <label className="block mb-1 font-semibold">Font Size</label>
+          <input
+            type="number"
+            className="w-full border rounded p-2 mb-2"
+            value={p.size}
+            onChange={(e) => updatePlaceholder(idx, 'size', Number(e.target.value))}
+          />
+          <label className="block mb-1 font-semibold">Color</label>
+          <input
+            type="color"
+            className="w-full border rounded p-2"
+            value={p.color}
+            onChange={(e) => updatePlaceholder(idx, 'color', e.target.value)}
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="mb-4 bg-gray-200 px-3 py-1 rounded"
+      >
+        Add Placeholder
+      </button>
       <h2 className="text-xl font-bold mb-2">Preview</h2>
       <div ref={cardRef} className="border rounded overflow-hidden relative">
-
         <img
           src={templates.find((t) => t.id === template).src}
           alt={template}
           className="w-full h-auto"
         />
-        <div className="absolute inset-0 flex items-center justify-center text-xl font-bold">
-          {message || 'Your message here'}
-        </div>
+        {placeholders.map((p, idx) => (
+          <div
+            key={p.id}
+            style={{
+              position: 'absolute',
+              left: p.x,
+              top: p.y,
+              transform: 'translate(-50%, -50%)',
+              fontFamily: p.font,
+              fontSize: p.size,
+              color: p.color,
+              cursor: 'move',
+            }}
+            onPointerDown={(e) => handlePointerDown(e, idx)}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+          >
+            {p.text || `Text ${idx + 1}`}
+          </div>
+        ))}
       </div>
       <div className="mt-4 flex gap-2">
         <button
@@ -102,7 +193,7 @@ function CardEditor() {
           Share Link
         </button>
       </div>
-      </div>
+    </div>
   )
 }
 

--- a/src/components/CardViewer.jsx
+++ b/src/components/CardViewer.jsx
@@ -1,0 +1,76 @@
+import { useState, useEffect, useRef } from 'react'
+import birthdayImg from '../assets/templates/birthday.svg'
+import congratsImg from '../assets/templates/congrats.svg'
+import holidayImg from '../assets/templates/holiday.svg'
+
+function CardViewer() {
+  const templates = [
+    { id: 'birthday', label: 'Birthday', src: birthdayImg },
+    { id: 'congrats', label: 'Congrats', src: congratsImg },
+    { id: 'holiday', label: 'Holiday', src: holidayImg },
+  ]
+
+  const cardRef = useRef(null)
+  const [cardData, setCardData] = useState(null)
+  const [values, setValues] = useState([])
+
+  useEffect(() => {
+    const id = window.location.pathname.split('/card/')[1]
+    const stored = localStorage.getItem(`card-${id}`)
+    if (stored) {
+      const data = JSON.parse(stored)
+      setCardData(data)
+      setValues(data.placeholders.map((p) => p.text))
+    }
+  }, [])
+
+  if (!cardData) {
+    return <div className="p-4 text-center">Card not found.</div>
+  }
+
+  const handleChange = (idx, val) => {
+    setValues((prev) => prev.map((v, i) => (i === idx ? val : v)))
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-4 text-blue-600">Your Card</h1>
+      <div ref={cardRef} className="border rounded overflow-hidden relative mb-4">
+        <img
+          src={templates.find((t) => t.id === cardData.template).src}
+          alt={cardData.template}
+          className="w-full h-auto"
+        />
+        {cardData.placeholders.map((p, idx) => (
+          <div
+            key={p.id}
+            style={{
+              position: 'absolute',
+              left: p.x,
+              top: p.y,
+              transform: 'translate(-50%, -50%)',
+              fontFamily: p.font,
+              fontSize: p.size,
+              color: p.color,
+              pointerEvents: 'none',
+            }}
+          >
+            {values[idx] || p.text}
+          </div>
+        ))}
+      </div>
+      {cardData.placeholders.map((p, idx) => (
+        <div key={p.id} className="mb-2">
+          <label className="block mb-1 font-semibold">Text {idx + 1}</label>
+          <input
+            value={values[idx]}
+            onChange={(e) => handleChange(idx, e.target.value)}
+            className="w-full border rounded p-2"
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default CardViewer


### PR DESCRIPTION
## Summary
- allow multiple draggable text placeholders in `CardEditor`
- save placeholder data and share `/card/:id` URLs
- add `CardViewer` to fill in shared cards
- route `/card/:id` paths in `App`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684060e681f0833383de435a4d17e2a9