### PR TITLE
Add download tracking API and viewer page

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.node },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"      },
+        "react-dom": "^19.1.0"
+      },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@tailwindcss/postcss": "^4.1.8",
@@ -1679,9 +1680,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
-      "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
+      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1872,9 +1873,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001721",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
+      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
       "dev": true,
       "funding": [
         {
@@ -2011,9 +2012,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.162",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.162.tgz",
-      "integrity": "sha512-hQA+Zb5QQwoSaXJWEAGEw1zhk//O7qDzib05Z4qTqZfNju/FAkrm5ZInp0JbTp4Z18A6bilopdZWEYrFSsfllA==",
+      "version": "1.5.165",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
+      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
       "dev": true,
       "license": "ISC"
     },
@@ -3533,6 +3534,7 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,48 @@
+import fs from 'fs'
+import path from 'path'
+import express from 'express'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const app = express();
+app.use(express.json());
+
+const DATA_FILE = path.join(__dirname, 'data', 'counts.json');
+function loadCounts() {
+  try {
+    const data = fs.readFileSync(DATA_FILE, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+function saveCounts(counts) {
+  fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true });
+  fs.writeFileSync(DATA_FILE, JSON.stringify(counts, null, 2));
+}
+
+app.get('/api/cards/:id/count', (req, res) => {
+  const counts = loadCounts();
+  const id = req.params.id;
+  const count = counts[id] || 0;
+  res.json({ count });
+});
+
+app.post('/api/cards/:id/increment', (req, res) => {
+  const counts = loadCounts();
+  const id = req.params.id;
+  counts[id] = (counts[id] || 0) + 1;
+  saveCounts(counts);
+  res.json({ count: counts[id] });
+});
+
+app.get('/api/cards/all', (req, res) => {
+  const counts = loadCounts();
+  res.json(counts);
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`API server listening on ${port}`);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,18 @@
 import heroImg from './assets/hero.svg'
 import './App.css'
 import CardEditor from './components/CardEditor.jsx'
+import CardViewer from './components/CardViewer.jsx'
+import AdminDashboard from './components/AdminDashboard.jsx'
 
 function App() {
   if (window.location.pathname.startsWith('/editor')) {
     return <CardEditor />
+  }
+  if (window.location.pathname.startsWith('/view')) {
+    return <CardViewer />
+  }
+  if (window.location.pathname.startsWith('/admin')) {
+    return <AdminDashboard />
   }
 
   return (

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+
+function AdminDashboard() {
+  const [counts, setCounts] = useState({})
+
+  useEffect(() => {
+    async function fetchCounts() {
+      const res = await fetch('/api/cards/all')
+      if (res.ok) {
+        const data = await res.json()
+        setCounts(data)
+      }
+    }
+    fetchCounts()
+  }, [])
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-4 text-blue-600">Admin Dashboard</h1>
+      <table className="w-full border">
+        <thead>
+          <tr>
+            <th className="border p-2 text-left">Card</th>
+            <th className="border p-2 text-left">Downloads</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(counts).map(([id, count]) => (
+            <tr key={id}>
+              <td className="border p-2">{id}</td>
+              <td className="border p-2">{count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default AdminDashboard

--- a/src/components/CardEditor.jsx
+++ b/src/components/CardEditor.jsx
@@ -26,6 +26,9 @@ function CardEditor() {
   const handleDownload = async () => {
     if (!cardRef.current) return
     try {
+      const cardId = `${template}:${message}`
+      await fetch(`/api/cards/${encodeURIComponent(cardId)}/increment`, { method: 'POST' })
+      // Wait for count to be incremented before creating the PNG
       const dataUrl = await toPng(cardRef.current)
       const link = document.createElement('a')
       link.download = 'card.png'

--- a/src/components/CardViewer.jsx
+++ b/src/components/CardViewer.jsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react'
+import { toPng } from '../utils/toPng'
+import birthdayImg from '../assets/templates/birthday.svg'
+import congratsImg from '../assets/templates/congrats.svg'
+import holidayImg from '../assets/templates/holiday.svg'
+
+function CardViewer() {
+  const templates = {
+    birthday: birthdayImg,
+    congrats: congratsImg,
+    holiday: holidayImg,
+  }
+  const cardRef = useRef(null)
+  const [message, setMessage] = useState('')
+  const [template, setTemplate] = useState('birthday')
+  const [count, setCount] = useState(0)
+  const cardId = `${template}:${message}`
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const m = params.get('message')
+    const t = params.get('template')
+    if (m) setMessage(m)
+    if (t && templates[t]) setTemplate(t)
+  }, [])
+
+  useEffect(() => {
+    async function fetchCount() {
+      const res = await fetch(`/api/cards/${encodeURIComponent(cardId)}/count`)
+      if (res.ok) {
+        const data = await res.json()
+        setCount(data.count)
+      }
+    }
+    fetchCount()
+  }, [cardId])
+
+  const handleDownload = async () => {
+    if (!cardRef.current) return
+    try {
+      await fetch(`/api/cards/${encodeURIComponent(cardId)}/increment`, {
+        method: 'POST',
+      })
+      const res = await fetch(`/api/cards/${encodeURIComponent(cardId)}/count`)
+      if (res.ok) {
+        const data = await res.json()
+        setCount(data.count)
+      }
+      const dataUrl = await toPng(cardRef.current)
+      const link = document.createElement('a')
+      link.download = 'card.png'
+      link.href = dataUrl
+      link.click()
+    } catch (err) {
+      console.error('Failed to export image', err)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-4 text-blue-600">Card Viewer</h1>
+      <div ref={cardRef} className="border rounded overflow-hidden relative">
+        <img src={templates[template]} alt={template} className="w-full h-auto" />
+        <div className="absolute inset-0 flex items-center justify-center text-xl font-bold">
+          {message || 'Your message here'}
+        </div>
+      </div>
+      <div className="mt-4 flex flex-col items-start gap-2">
+        <button
+          type="button"
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          onClick={handleDownload}
+        >
+          Download PNG
+        </button>
+        <div className="text-sm text-gray-700">Downloads: {count}</div>
+      </div>
+    </div>
+  )
+}
+
+export default CardViewer

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- create Node API server to store card download counts
- proxy `/api` requests in Vite dev server
- track downloads from editor and new viewer component
- show download total in viewer
- add admin dashboard to list counts

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684060ecc9b883338a9e170d642c8666